### PR TITLE
Official artwork spriteUrl

### DIFF
--- a/scripts/fill-db.ts
+++ b/scripts/fill-db.ts
@@ -10,7 +10,7 @@ const doBackfill = async () => {
   const formattedPokemon = allPokemon.results.map((p, index) => ({
     id: index + 1,
     name: (p as { name: string }).name,
-    spriteUrl: `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${
+    spriteUrl: `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/${
       index + 1
     }.png`,
   }));


### PR DESCRIPTION
I heard you were wondering about stripping the artwork from Pokemondb or Bulbapedia, but the pokeapi (more specifically pokenode-ts) has an original artwork sprite property.

Example URL
```
https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/267.png
```

In Pokenode-ts
```ts
pokemon.sprites.other['official-artwork'].front_default
```

I believe you would just need to run the back-fill script to apply changes, right? Great content!