### PR TITLE
Add image-rendering: pixelated

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -94,6 +94,7 @@ const PokemonListing: React.FC<{
 }> = (props) => {
   return (
     <div
+      style="image-rendering: pixelated"
       className={`flex flex-col items-center transition-opacity ${
         props.disabled && "opacity-0"
       }`}


### PR DESCRIPTION
Because Tailwind does not have an image-rendering-pixelated class, I had to use inline styles. Hopefully won't be an issue.